### PR TITLE
Fix for client.lua:437: attempt to call method 'Destroy' (a nil value)

### DIFF
--- a/lua/shine/extensions/captainsmode/client.lua
+++ b/lua/shine/extensions/captainsmode/client.lua
@@ -434,5 +434,5 @@ end
 function Plugin:Cleanup()
 	self.BaseClass.Cleanup(self)
 
-	CaptainMenu:Destroy()
+	CaptainMenu.Window:Destroy()
 end


### PR DESCRIPTION
I'm new to modding NS2 but a server was using this mod and got the below error. According to API docs the Destroy method is on the SGUI Window object.
Fix for:
Plugin cleanup error: lua/shine/extensions/captainsmode/client.lua:437: attempt to call method 'Destroy' (a nil value)
Stack traceback:
    lua/shine/extensions/captainsmode/client.lua:437 in function <lua/shine/extensions/captainsmode/client.lua:434>
        CaptainMenu = table: 0x6d15e0b8 (0 array elements, not empty)
        self = table: 0x6d152410 (0 array elements, not empty)